### PR TITLE
Change output method in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,8 +13,6 @@ jobs:
   prepare:
     name: Prepare env & label
     runs-on: ubuntu-latest
-    outputs:
-      get_current_tag: ${{ steps.set_current_tag_id.outputs.current_tag }}
     steps:
 
       - name: Checkout code

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Set tag version to output
         id: set_current_tag_id
-        run: echo "::set-output name=current_tag::${{ steps.tag_version.outputs.new_tag }}"
+        run: echo "CURRENT_TAG=${{ steps.tag_version.outputs.new_tag }}" >> $GITHUB_OUTPUT
 
       - name: Notify if failure
         if: ${{ failure() }}
@@ -57,8 +57,6 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     needs: prepare
-    outputs:
-      get_release_url: ${{ steps.set_release_url.outputs.release_url }}
     steps:
 
       - name: Build Changelog
@@ -76,12 +74,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.REPOS_TOKEN }}
         with:
           tag_name: ${{ needs.prepare.outputs.get_current_tag }}
-          release_name: Release ${{ needs.prepare.outputs.get_current_tag }}
+          release_name: Release ${{ needs.prepare.outputs.CURRENT_TAG }}
           body: ${{ steps.github_release.outputs.changelog }}
 
       - name: Set Release URL
         id: set_release_url
-        run: echo "::set-output name=release_url::${{ steps.create_release.outputs.upload_url }}"
+        run: echo "RELEASE_URL=${{ steps.create_release.outputs.upload_url }}" >> $GITHUB_OUTPUT
 
       - name: Notify if failure
         if: ${{ failure() }}
@@ -145,7 +143,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ needs.release.outputs.get_release_url }}
+          upload_url: ${{ needs.release.outputs.RELEASE_URL }}
           asset_path: ./dist/${{ matrix.OUT_FILE_NAME }}
           asset_name: ${{ matrix.OUT_FILE_NAME }}
           asset_content_type: ${{ matrix.ASSET_MIME }}
@@ -180,7 +178,7 @@ jobs:
 
             <b>WorkFlows:</b> <a href="https://github.com/${{ github.repository }}/actions">ActionsList</a>
 
-            Commit with tag: ${{ needs.prepare.outputs.get_current_tag }}
+            Commit with tag: ${{ needs.prepare.outputs.CURRENT_TAG }}
 
             Repository: ${{ github.repository }}
 


### PR DESCRIPTION
## What does this PR do ?
The feautre of github actions core deprecated soon

## Why is it important ?
To avoid security risks & actions running problem 

## How to test it ?
Just push some commit and make PR to develop if not yet requested 